### PR TITLE
Hosting Team Code Review Changes

### DIFF
--- a/src/main/java/io/prismacloud/iac/jenkins/Config.java
+++ b/src/main/java/io/prismacloud/iac/jenkins/Config.java
@@ -22,8 +22,10 @@ import hudson.util.FormValidation;
 import hudson.util.Secret;
 import javax.annotation.CheckForNull;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 @Extension
 public final class Config
@@ -70,6 +72,7 @@ extends GlobalConfiguration {
         this.save();
     }
 
+    @POST
     public FormValidation doCheckUsername(@QueryParameter String value) {
         if (value.length() == 0) {
             return FormValidation.error((String)"Please set access key");
@@ -77,6 +80,7 @@ extends GlobalConfiguration {
         return FormValidation.ok();
     }
 
+    @POST
     public FormValidation doCheckPassword(@QueryParameter String value) {
         if (value.length() == 0) {
             return FormValidation.error((String)"Please set secret key");
@@ -84,6 +88,7 @@ extends GlobalConfiguration {
         return FormValidation.ok();
     }
 
+    @POST
     public FormValidation doCheckAddress(@QueryParameter String value) {
         if (value.length() == 0) {
             return FormValidation.error((String)"Please set auth URL");
@@ -95,6 +100,7 @@ extends GlobalConfiguration {
     }
 
     public FormValidation doTestConnection(@QueryParameter(value="address") String address, @QueryParameter(value="username") String username, @QueryParameter(value="password") String password) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         try {
             PrismaCloudServiceImpl prismaCloudService = new PrismaCloudServiceImpl();
             PrismaCloudConfiguration prismaCloudConfiguration = new PrismaCloudConfiguration();

--- a/src/main/resources/io/prismacloud/iac/jenkins/Config/config.jelly
+++ b/src/main/resources/io/prismacloud/iac/jenkins/Config/config.jelly
@@ -14,15 +14,15 @@
   -->
   <f:section title="Prisma Cloud">
     <f:entry field="address" title="Auth URL" description="Prisma Cloud Auth URL, formatted as https://authURL">
-        <f:textbox />
+        <f:textbox  checkMethod="post"/>
     </f:entry>
 
     <f:entry field="username" title="Access Key" description="Prisma Cloud access key used to authenticate to the Prisma Cloud API">
-        <f:textbox />
+        <f:textbox  checkMethod="post"/>
     </f:entry>
 
     <f:entry field="password" title="Secret Key" description="Prisma Cloud secret key">
-        <f:password />
+        <f:password checkMethod="post" />
     </f:entry>
     <f:validateButton
           title="Test Connection" progress="Testing..."


### PR DESCRIPTION
BLOCKING Items

Your doTestConnection method needs to follow the recommendations in the secure form validation documentation, see https://www.jenkins.io/doc/developer/security/form-validation/
https://github.com/prisma-cloud-shiftleft/iac-jenkins-plugin/blob/51ba6fd2012432b7a7c3f12be97cf6283b2decde/src/main/java/io/prismacloud/iac/jenkins/Config.java#L97
Please also look at the other doCheck methods to verify they follow the recommendations as well (some may not need it as they don't have side effects or have the possibility of exposing sensitive information)
If you are storing the username as a hudson.util.Secret, then you probably shouldn't be logging the value to the console. See below about the username.
https://github.com/prisma-cloud-shiftleft/iac-jenkins-plugin/blob/main/src/main/java/io/prismacloud/iac/jenkins/TemplateScanBuilder.java#L257
Non-Blocking Items

User names don't need to be stored as hudson.util.Secrets, it won't hurt anything, just and FYI.
https://github.com/prisma-cloud-shiftleft/iac-jenkins-plugin/blob/51ba6fd2012432b7a7c3f12be97cf6283b2decde/src/main/java/io/prismacloud/iac/jenkins/Config.java#L33
You probably want to add an @Symbol annotation to your Descriptor for your Builder implementation, this will allow users to use your plugin more easily from pipeline jobs
Something like @Symbol("prismaIaC") or similar. 
https://github.com/prisma-cloud-shiftleft/iac-jenkins-plugin/blob/main/src/main/java/io/prismacloud/iac/jenkins/TemplateScanBuilder.java#L166
This method of getting the job name will not work in pipeline as pipeline can create workspaces with different names, I would recommend using the Run object that you get in the perform method to get the job name